### PR TITLE
docs: add Cloudflare WARP (WARP-remna.md) link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@
 - 🐳 Docker  
 - 🔐 безопасности серверов  
 - 📡 прокси и сетевым сервисам  
+- ☁️ Cloudflare WARP для remnanode — [WARP-remna.md](https://github.com/r00t-man/MZT/blob/main/my-wiki/WARP-remna.md)  
 - 🧹 обслуживанию VPS  
 
 ---
@@ -95,6 +96,7 @@ MZT
 │   ├── Audit-history.md
 │   ├── Docker control.md
 │   ├── MTProxy_TG.md
+│   ├── WARP-remna.md
 │   └── Ultra Clean VPS.md
 │
 └── VPN Guides


### PR DESCRIPTION
### Motivation
- Make the new Cloudflare WARP guide discoverable from the main README by adding a link to `WARP-remna.md`.

### Description
- Added a `☁️ Cloudflare WARP для remnanode — [WARP-remna.md](https://github.com/r00t-man/MZT/blob/main/my-wiki/WARP-remna.md)` entry under "Основные гайды" and included `WARP-remna.md` in the repository tree section of `README.md`.

### Testing
- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aec08226188332b2c33ad8f389ce12)