### PR TITLE
Document Cloudflare WARP (remnanode) installer in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
 | 🔐 **Audit History** | Логирование команд Linux | `bash <(curl -Ls https://raw.githubusercontent.com/r00t-man/MZT/main/files/audit-history.sh)` |
 | 📡 **MTProto Proxy** | Установка MTProxy для Telegram | `bash <(curl -Ls https://raw.githubusercontent.com/r00t-man/MZT/main/files/tg_mtproxy.sh)` |
 | 🌐 **SOCKS5 Proxy (Dante)** | Менеджер пользователей SOCKS5 | `bash <(curl -fsSL https://raw.githubusercontent.com/r00t-man/MZT/main/files/Proxy_socks5_dante.sh)` |
+| ☁️ **Cloudflare WARP (remnanode)** | Установка и настройка WARP для remnanode | `bash <(curl -Ls https://raw.githubusercontent.com/r00t-man/MZT/main/files/warp-remnanode.sh)` |
 
 ---
 
@@ -95,6 +96,7 @@ MZT
 │   ├── Audit-history.md
 │   ├── Docker control.md
 │   ├── MTProxy_TG.md
+│   ├── WARP-remna.md
 │   └── Ultra Clean VPS.md
 │
 └── VPN Guides


### PR DESCRIPTION
### Motivation
- Add documentation and quick-install entry for a new Cloudflare WARP installer targeted at "remnanode" to make the script discoverable from the repository README.

### Description
- Added a new one-click install table row referencing the installer script `files/warp-remnanode.sh` and labeled it "Cloudflare WARP (remnanode)".
- Updated the repository structure section to include the new wiki page `my-wiki/WARP-remna.md`.

### Testing
- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aec08226188332b2c33ad8f389ce12)