### PR TITLE
docs: add pre-cleanup backup instructions to Ultra Clean VPS guide

### DIFF
--- a/my-wiki/Ultra Clean VPS.md
+++ b/my-wiki/Ultra Clean VPS.md
@@ -36,6 +36,30 @@ curl -fsSL https://raw.githubusercontent.com/r00t-man/MZT/refs/heads/main/files/
 
 ---
 
+# 💾 Бэкап перед очисткой (рекомендуется)
+
+Если на диске есть запас места, перед запуском очистки можно сохранить удаляемые данные в архив.
+
+### Вариант одной командой (бэкап в `/backup_ultra_clean`)
+
+```bash
+sudo bash -c 'command -v tar >/dev/null || (apt update && apt install -y tar); TS=$(date +%F_%H-%M-%S); mkdir -p /backup_ultra_clean; tar -czf /backup_ultra_clean/ultra_clean_backup_${TS}.tar.gz /var/log/journal /var/lib/apt/lists /var/cache/apt/archives /tmp /var/tmp /var/lib/docker 2>/dev/null || true; ls -lh /backup_ultra_clean'
+```
+
+Что делает команда:
+
+* проверяет наличие `tar` (обычно уже установлен в Ubuntu 24.04)
+* при необходимости устанавливает архиватор
+* создаёт каталог `/backup_ultra_clean`
+* собирает архив с датой и временем в имени
+* показывает итоговый размер бэкапа.
+
+После этого можно запускать `Ultra_Clean_VPS.sh`.
+
+> ⚠️ Если Docker не установлен или часть путей отсутствует — это нормально, команда продолжит работу.
+
+---
+
 # 📥 Скачать скрипт
 
 Если хотите сначала скачать файл:


### PR DESCRIPTION
### Motivation

- Добавить инструкцию в `my-wiki/Ultra Clean VPS.md` о создании резервной копии перед запуском очистки для случаев, когда на диске достаточно места, чтобы избежать потери данных при удалении файлов скриптом `Ultra_Clean_VPS.sh`.

### Description

- Добавлен раздел «Бэкап перед очисткой» в `my-wiki/Ultra Clean VPS.md`, включающий однострочную команду, которая проверяет наличие `tar`, устанавливает его при необходимости, создаёт `/backup_ultra_clean`, архивирует ключевые пути (`/var/log/journal`, `/var/lib/apt/lists`, `/var/cache/apt/archives`, `/tmp`, `/var/tmp`, `/var/lib/docker`) в timestamped `ultra_clean_backup_<TS>.tar.gz` и показывает результат.

### Testing

- Проверил содержимое и изменения с помощью `git -C /workspace/MZT status --short`, просмотра разницы `git -C /workspace/MZT diff -- 'my-wiki/Ultra Clean VPS.md'` и инспекции файла через `nl -ba 'my-wiki/Ultra Clean VPS.md' | sed -n '30,90p'`, все проверки прошли успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afdbcde5148332967c25260a91bcdf)