### PR TITLE
docs: convert Ubuntu 24 command cheat sheet into VPN-node preparation guide

### DIFF
--- a/info/Тестовая статья — основные команды Ubuntu 24.md
+++ b/info/Тестовая статья — основные команды Ubuntu 24.md
@@ -1,202 +1,260 @@
-# 🧪 Тестовая статья: основные команды Ubuntu 24
+# 🧪 Тестовая статья: базовые команды Ubuntu 24 для подготовки VPN-ноды
 
-Эта статья создана как тестовый материал для раздела `info` и содержит базовый набор команд, которые полезны при ежедневной работе в **Ubuntu 24.04 LTS**.
+Эта статья обновлена как **универсальный стартовый чеклист** для чистой **Ubuntu 24.04 LTS**: от первичной подготовки сервера до базового hardening под VPN-ноду.
+
+> ⚠️ Команды ниже даны как безопасная база. Подставляйте свои значения: `USERNAME`, `SSH_PORT`, `SERVER_IP`, `VPN_PORTS`.
 
 ---
 
-## 1) Обновление системы
+## 0) Быстрая логика подготовки
+
+1. Обновить систему и поставить базовые пакеты.
+2. Создать отдельного sudo-пользователя.
+3. Настроить SSH-ключи и усилить SSH.
+4. Включить firewall (в репозитории используется `nftables`) и открыть только нужные порты.
+5. Включить Fail2Ban.
+6. Применить базовые сетевые sysctl-параметры.
+7. Проверить время, логи, открытые сокеты и автозапуск сервисов.
+
+---
+
+## 1) Обновление системы (чистый сервер)
 
 ```bash
 sudo apt update
-sudo apt upgrade -y
-```
-
-- `apt update` — обновляет список доступных пакетов.
-- `apt upgrade -y` — устанавливает обновления для уже установленных пакетов.
-
-Полезно дополнительно:
-
-```bash
 sudo apt full-upgrade -y
 sudo apt autoremove -y
+sudo apt autoclean -y
+sudo reboot
+```
+
+После перезагрузки:
+
+```bash
+cat /etc/os-release
+uname -r
 ```
 
 ---
 
-## 2) Работа с пакетами
-
-Установка пакета:
+## 2) Установка базовых пакетов для администрирования и защиты
 
 ```bash
-sudo apt install htop -y
+sudo apt install -y \
+  curl wget ca-certificates gnupg lsb-release \
+  git vim nano htop tmux jq unzip \
+  openssl rsync socat \
+  fail2ban nftables
 ```
 
-Удаление пакета:
+Опционально (автообновления безопасности):
 
 ```bash
-sudo apt remove htop -y
-```
-
-Поиск пакета:
-
-```bash
-apt search nginx
-```
-
-Информация о пакете:
-
-```bash
-apt show nginx
+sudo apt install -y unattended-upgrades
+sudo dpkg-reconfigure -plow unattended-upgrades
 ```
 
 ---
 
-## 3) Проверка версии и информации о системе
+## 3) Создание отдельного пользователя и sudo
 
 ```bash
-lsb_release -a
-uname -a
-hostnamectl
+sudo adduser USERNAME
+sudo usermod -aG sudo USERNAME
+id USERNAME
 ```
 
-- `lsb_release -a` — версия дистрибутива.
-- `uname -a` — информация о ядре.
-- `hostnamectl` — имя хоста и данные системы.
-
----
-
-## 4) Файлы и каталоги
+Проверка sudo от нового пользователя:
 
 ```bash
-pwd
-ls -la
-cd /etc
-mkdir test-dir
-touch test.txt
-cp test.txt test-copy.txt
-mv test-copy.txt renamed.txt
-rm renamed.txt
-```
-
-Кратко:
-- `pwd` — текущая директория.
-- `ls -la` — список файлов с правами.
-- `cp`, `mv`, `rm` — копирование, перемещение, удаление.
-
----
-
-## 5) Просмотр диска и памяти
-
-```bash
-df -h
-du -sh /var/log/*
-free -h
-```
-
-- `df -h` — занятость файловых систем.
-- `du -sh` — размер каталогов/файлов.
-- `free -h` — состояние ОЗУ и swap.
-
----
-
-## 6) Пользователи и права
-
-```bash
-whoami
-id
-sudo adduser demo
-sudo usermod -aG sudo demo
-```
-
-Права на файл:
-
-```bash
-chmod 644 file.txt
-chown user:user file.txt
+su - USERNAME
+sudo -v
 ```
 
 ---
 
-## 7) Сеть и диагностика
+## 4) SSH-ключи и безопасный SSH
+
+На сервере (под нужным пользователем):
 
 ```bash
-ip a
-ip r
-ping -c 4 8.8.8.8
-ss -tulpen
-curl -I https://ubuntu.com
+mkdir -p ~/.ssh
+chmod 700 ~/.ssh
+nano ~/.ssh/authorized_keys
+chmod 600 ~/.ssh/authorized_keys
 ```
 
-- `ip a` — сетевые интерфейсы.
-- `ip r` — таблица маршрутизации.
-- `ss -tulpen` — активные порты и сокеты.
+Базовый блок в `/etc/ssh/sshd_config`:
 
----
-
-## 8) Сервисы systemd
-
-Проверить статус:
-
-```bash
-systemctl status ssh
+```ini
+Port SSH_PORT
+PubkeyAuthentication yes
+PasswordAuthentication no
+PermitRootLogin prohibit-password
+X11Forwarding no
+MaxAuthTries 3
+ClientAliveInterval 300
+ClientAliveCountMax 2
 ```
 
-Запустить/остановить/перезапустить:
+Проверка и перезапуск:
 
 ```bash
-sudo systemctl start ssh
-sudo systemctl stop ssh
+sudo sshd -t
 sudo systemctl restart ssh
+sudo systemctl status ssh --no-pager
 ```
 
-Включить автозапуск:
+> Перед сменой SSH-порта обязательно заранее откройте его в firewall.
+
+---
+
+## 5) Firewall (nftables) — минимальная универсальная база
+
+Создать правила `/etc/nftables.conf`:
+
+```nft
+#!/usr/sbin/nft -f
+flush ruleset
+
+table inet filter {
+  chain input {
+    type filter hook input priority 0;
+    policy drop;
+
+    iif "lo" accept
+    ct state established,related accept
+
+    # ICMP (пинг/диагностика)
+    ip protocol icmp accept
+    ip6 nexthdr icmpv6 accept
+
+    # SSH
+    tcp dport SSH_PORT accept
+
+    # VPN-порты (пример)
+    tcp dport { 443 } accept
+    udp dport { 443 } accept
+  }
+
+  chain forward {
+    type filter hook forward priority 0;
+    policy drop;
+  }
+
+  chain output {
+    type filter hook output priority 0;
+    policy accept;
+  }
+}
+```
+
+Применить:
 
 ```bash
-sudo systemctl enable ssh
-sudo systemctl disable ssh
+sudo nft -f /etc/nftables.conf
+sudo systemctl enable nftables
+sudo systemctl restart nftables
+sudo nft list ruleset
 ```
 
 ---
 
-## 9) Логи
+## 6) Fail2Ban для SSH
 
-```bash
-journalctl -xe
-journalctl -u ssh --since "today"
+`/etc/fail2ban/jail.local`:
+
+```ini
+[sshd]
+enabled = true
+port = SSH_PORT
+filter = sshd
+backend = systemd
+findtime = 600
+maxretry = 3
+bantime = 1h
+action = nftables[name=SSH, port=ssh, protocol=tcp]
 ```
 
-Просмотр системного лога в реальном времени:
+Запуск и проверка:
 
 ```bash
-sudo tail -f /var/log/syslog
+sudo systemctl enable fail2ban
+sudo systemctl restart fail2ban
+sudo fail2ban-client status
+sudo fail2ban-client status sshd
 ```
 
 ---
 
-## 10) Полезные команды для администрирования
+## 7) Базовый sysctl-hardening
 
-```bash
-ps aux | grep nginx
-top
-htop
-uptime
-history
+Создать файл `/etc/sysctl.d/99-vpn-node.conf`:
+
+```conf
+# Базовая сетевая гигиена
+net.ipv4.tcp_syncookies = 1
+net.ipv4.conf.all.rp_filter = 1
+net.ipv4.conf.default.rp_filter = 1
+net.ipv4.icmp_echo_ignore_broadcasts = 1
+net.ipv4.icmp_ignore_bogus_error_responses = 1
+
+# Если VPN требует маршрутизацию/NAT — включить:
+net.ipv4.ip_forward = 1
 ```
 
-- `ps aux` — список процессов.
-- `top` / `htop` — мониторинг ресурсов.
-- `history` — история команд.
+Применить:
+
+```bash
+sudo sysctl --system
+sysctl net.ipv4.ip_forward
+```
 
 ---
 
-## Мини-чеклист после установки Ubuntu 24
+## 8) DNS и время (важно для TLS/сертификатов)
 
-1. Обновить систему (`apt update && apt upgrade`).
-2. Установить базовые утилиты: `curl`, `wget`, `htop`, `git`, `ufw`.
-3. Проверить доступ по SSH и отключить вход по паролю (если сервер).
-4. Настроить файрвол (`ufw`).
-5. Проверить логи и автозагрузку сервисов.
+Проверка времени и таймзоны:
+
+```bash
+timedatectl
+sudo timedatectl set-timezone UTC
+```
+
+Проверка DNS:
+
+```bash
+resolvectl status
+resolvectl query github.com
+```
 
 ---
 
-> 💡 Подсказка: перед потенциально опасными командами (удаление, изменение прав, обновление критичных пакетов) удобно создавать резервные копии конфигов и использовать `tmux`/`screen` при удалённой работе.
+## 9) Что проверить перед установкой VPN-панели/ядра
+
+```bash
+ip -br a
+ip r
+ss -tulpen
+sudo systemctl --failed
+sudo journalctl -p err -b --no-pager
+```
+
+Если всё чисто — можно переходить к установке VPN-стека (например, 3X-UI/Xray).
+
+---
+
+## 10) Мини-чеклист «сервер готов к VPN-ноде»
+
+- [ ] Система обновлена и перезагружена.
+- [ ] Создан отдельный sudo-пользователь.
+- [ ] Вход по SSH только по ключам.
+- [ ] Сменён стандартный SSH-порт.
+- [ ] `nftables` включён, открыты только нужные порты.
+- [ ] `fail2ban` активен и видит `sshd` jail.
+- [ ] Применён `sysctl` профиль.
+- [ ] Проверены DNS, время и ошибки в журналах.
+
+---
+
+> 💡 Практика: перед сетевыми изменениями держите 2 SSH-сессии (рабочую и резервную), а при удалённой настройке используйте `tmux`.


### PR DESCRIPTION
### Motivation
- Bring the repository documentation in line with the VPN-focused content by turning a generic Ubuntu-24 commands cheat sheet into a practical bootstrap/checklist for deploying a VPN node. 
- Provide a single, opinionated, minimal and safe set of commands/config snippets for a clean Ubuntu 24.04 LTS server to prepare it for VPN software (3X-UI/Xray etc.).
- Reduce ad-hoc edits by offering ready-to-use templates for `sshd_config`, `nftables`, `fail2ban` and `sysctl` tuned for VPN nodes.

### Description
- Rewrote `info/Тестовая статья — основные команды Ubuntu 24.md` into `info/Тестовая статья — базовые команды Ubuntu 24 для подготовки VPN-ноды` with a step-by-step bootstrap flow covering updates, base packages, user/sudo creation, SSH hardening, firewall (`nftables`) baseline, `fail2ban`, `sysctl` hardening, DNS/time checks and pre-install diagnostics. 
- Added concrete example blocks for `sshd_config`, `/etc/nftables.conf`, `/etc/fail2ban/jail.local` and `/etc/sysctl.d/99-vpn-node.conf` that use placeholders (`USERNAME`, `SSH_PORT`, `VPN_PORTS`) for safe customization. 
- Included a final readiness checklist and short operational guidance (two SSH sessions, use of `tmux`) to reduce lockout risk during remote configuration.

### Testing
- Printed and reviewed the updated file contents with `sed -n '1,260p' info/'Тестовая статья — основные команды Ubuntu 24.md'` and `nl -ba` to verify structure and code blocks were rendered correctly. 
- Verified repository formatting and whitespace with `git diff --check` and checked working tree state with `git status --short`, both reporting no issues. 
- Applied the file update locally (commit created) and ensured the modified markdown contains the expected templates and checklist entries as shown in the preview outputs, with no automated failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afe03595e883329549c458528ebfd6)