### PR TITLE
Add GitHub Pages site catalog in `site/`

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -1,0 +1,17 @@
+# MZT GitHub Pages site
+
+Статика для публикации на GitHub Pages находится в этой папке.
+
+## Как включить публикацию
+
+1. Откройте `Settings` репозитория на GitHub.
+2. Перейдите в раздел `Pages`.
+3. В `Build and deployment` выберите:
+   - `Source`: `Deploy from a branch`
+   - `Branch`: `main`
+   - `Folder`: `/site`
+4. Сохраните настройки.
+
+После этого сайт будет доступен по адресу вида:
+
+`https://<owner>.github.io/<repo>/`

--- a/site/app.js
+++ b/site/app.js
@@ -1,0 +1,102 @@
+async function loadIndex() {
+  const response = await fetch('content-index.json');
+  if (!response.ok) throw new Error('Не удалось загрузить content-index.json');
+  return response.json();
+}
+
+function detectRepoContext() {
+  const host = window.location.hostname;
+  const pathParts = window.location.pathname.split('/').filter(Boolean);
+
+  const owner = host.endsWith('.github.io') ? host.replace('.github.io', '') : '<owner>';
+  const repo = pathParts.length > 0 ? pathParts[0] : 'MZT';
+  const branch = 'main';
+
+  return { owner, repo, branch };
+}
+
+function githubUrls(ctx, filePath) {
+  return {
+    blob: `https://github.com/${ctx.owner}/${ctx.repo}/blob/${ctx.branch}/${filePath}`,
+    raw: `https://raw.githubusercontent.com/${ctx.owner}/${ctx.repo}/${ctx.branch}/${filePath}`,
+    repo: `https://github.com/${ctx.owner}/${ctx.repo}`,
+  };
+}
+
+function renderCatalog(index, ctx) {
+  const catalog = document.getElementById('catalog');
+  const stats = document.getElementById('stats');
+  const search = document.getElementById('search');
+
+  const allItems = index.sections.flatMap((section) =>
+    section.files.map((file) => ({ section: section.name, path: file }))
+  );
+
+  function render(filteredItems) {
+    stats.textContent = `Показано файлов: ${filteredItems.length}`;
+
+    const bySection = new Map();
+    for (const item of filteredItems) {
+      if (!bySection.has(item.section)) bySection.set(item.section, []);
+      bySection.get(item.section).push(item.path);
+    }
+
+    catalog.innerHTML = '';
+    for (const [sectionName, files] of bySection.entries()) {
+      const section = document.createElement('article');
+      section.className = 'section';
+      section.innerHTML = `<div class="section-header">${sectionName} · ${files.length}</div>`;
+
+      const ul = document.createElement('ul');
+      ul.className = 'file-list';
+
+      files.forEach((filePath) => {
+        const urls = githubUrls(ctx, filePath);
+        const li = document.createElement('li');
+        li.className = 'file-item';
+        li.innerHTML = `
+          <span class="file-name">${filePath}</span>
+          <span class="file-links">
+            <a href="${urls.blob}" target="_blank" rel="noopener">GitHub</a>
+            <a href="${urls.raw}" target="_blank" rel="noopener">Raw</a>
+          </span>
+        `;
+        ul.appendChild(li);
+      });
+
+      section.appendChild(ul);
+      catalog.appendChild(section);
+    }
+  }
+
+  render(allItems);
+
+  search.addEventListener('input', (event) => {
+    const term = event.target.value.trim().toLowerCase();
+    if (!term) return render(allItems);
+
+    const filtered = allItems.filter((item) =>
+      item.path.toLowerCase().includes(term) || item.section.toLowerCase().includes(term)
+    );
+    render(filtered);
+  });
+}
+
+async function init() {
+  const ctx = detectRepoContext();
+  const repoLink = document.getElementById('repo-link');
+  const repoMeta = document.getElementById('repo-meta');
+
+  const repoUrl = `https://github.com/${ctx.owner}/${ctx.repo}`;
+  repoLink.href = repoUrl;
+  repoMeta.textContent = `Репозиторий: ${ctx.owner}/${ctx.repo} · ветка: ${ctx.branch}`;
+
+  try {
+    const index = await loadIndex();
+    renderCatalog(index, ctx);
+  } catch (error) {
+    repoMeta.textContent = `Ошибка: ${error.message}`;
+  }
+}
+
+init();

--- a/site/content-index.json
+++ b/site/content-index.json
@@ -1,0 +1,75 @@
+{
+  "sections": [
+    {
+      "name": "files",
+      "files": [
+        "files/audit-history.sh",
+        "files/control-docker-v5.2-cli.sh",
+        "files/Proxy_socks5_dante.sh",
+        "files/tg_mtproxy.sh",
+        "files/Ultra_Clean_VPS.sh",
+        "files/warp-remnanode.sh"
+      ]
+    },
+    {
+      "name": "help",
+      "files": [
+        "help/Programms.md"
+      ]
+    },
+    {
+      "name": "info",
+      "files": [
+        "info/README.md",
+        "info/Базовые команды Ubuntu 24 для подготовки VPN-ноды.md",
+        "info/Балансировка remna.md",
+        "info/Правила маршрутизации Remna.md"
+      ]
+    },
+    {
+      "name": "my-wiki",
+      "files": [
+        "my-wiki/Audit-history.md",
+        "my-wiki/Docker control.md",
+        "my-wiki/MTProxy_TG.md",
+        "my-wiki/Proxy SOCKS5 manager.md",
+        "my-wiki/readme.md",
+        "my-wiki/Ultra Clean VPS.md",
+        "my-wiki/WARP-remna.md"
+      ]
+    },
+    {
+      "name": "Server_Security",
+      "files": [
+        "Server_Security/02_Настройка безопасности сервера.md",
+        "Server_Security/03_Безопасная настройка sudo.md",
+        "Server_Security/06_Настройка безопасности sysctl.conf.md",
+        "Server_Security/07_Настройка SSH-ключей.md",
+        "Server_Security/12_Безопасная DNS-конфигурация сервера (DoT + DNSSEC).md",
+        "Server_Security/13_Сетевой кейс VPS маски 24 и 32.md",
+        "Server_Security/README.md"
+      ]
+    },
+    {
+      "name": "VPN_3x-ui",
+      "files": [
+        "VPN_3x-ui/00_Введение в технологию.md",
+        "VPN_3x-ui/01_Установка своего VPN.md",
+        "VPN_3x-ui/04_Настройка каскадного VPN.md",
+        "VPN_3x-ui/05_Настройка правил для доменов.md",
+        "VPN_3x-ui/08_Установка собственного DNS.md",
+        "VPN_3x-ui/09_Настройка DNS (DoT) на VPN.md",
+        "VPN_3x-ui/10_Настройка DNS (DoH) на VPN.md",
+        "VPN_3x-ui/11_DNS (DoT) - Возможна ошибка.md",
+        "VPN_3x-ui/14_Размывка трафика VPN.md"
+      ]
+    },
+    {
+      "name": "Корень репозитория",
+      "files": [
+        "LICENSE",
+        "README.md"
+      ]
+    }
+  ]
+}

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>MZT · GitHub Pages</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="hero">
+    <div class="container">
+      <p class="kicker">GitHub Pages</p>
+      <h1>MZT Knowledge Base</h1>
+      <p class="subtitle">
+        Каталог материалов репозитория: инструкции по VPN, безопасности серверов, скрипты и wiki-заметки.
+      </p>
+      <div class="repo-meta" id="repo-meta">Определяем параметры репозитория…</div>
+      <div class="actions">
+        <a class="btn" id="repo-link" href="#" target="_blank" rel="noopener">Открыть репозиторий</a>
+        <a class="btn btn-ghost" href="https://pages.github.com/" target="_blank" rel="noopener">GitHub Pages Docs</a>
+      </div>
+    </div>
+  </header>
+
+  <main class="container">
+    <section class="controls">
+      <input id="search" type="search" placeholder="Поиск по файлам и разделам…" />
+      <span id="stats"></span>
+    </section>
+
+    <section id="catalog" class="catalog"></section>
+  </main>
+
+  <footer class="container footer">
+    <p>
+      Сайт находится в папке <code>site/</code>. Для публикации включите GitHub Pages для ветки и директории
+      <code>/site</code>.
+    </p>
+  </footer>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/site/styles.css
+++ b/site/styles.css
@@ -1,0 +1,113 @@
+:root {
+  --bg: #0b1020;
+  --surface: #121a31;
+  --surface-2: #1c2646;
+  --text: #eaf1ff;
+  --muted: #9fb0d4;
+  --accent: #6fa8ff;
+  --accent-2: #8de7c9;
+  --border: #2f3c64;
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: Inter, Segoe UI, Roboto, sans-serif;
+  background: radial-gradient(circle at top right, #172347 0%, var(--bg) 45%);
+  color: var(--text);
+}
+
+.container {
+  width: min(1100px, 92vw);
+  margin: 0 auto;
+}
+
+.hero {
+  border-bottom: 1px solid var(--border);
+  padding: 3rem 0 2rem;
+}
+.kicker {
+  color: var(--accent-2);
+  text-transform: uppercase;
+  letter-spacing: .12em;
+  font-size: .8rem;
+  margin: 0 0 .6rem;
+}
+h1 { margin: 0 0 .5rem; font-size: clamp(2rem, 3vw, 3rem); }
+.subtitle { color: var(--muted); max-width: 70ch; }
+.repo-meta { margin: 1rem 0; color: var(--accent-2); }
+.actions { display: flex; gap: .8rem; flex-wrap: wrap; }
+
+.btn {
+  display: inline-block;
+  color: #041430;
+  background: var(--accent);
+  text-decoration: none;
+  font-weight: 600;
+  padding: .7rem 1rem;
+  border-radius: .6rem;
+}
+.btn-ghost {
+  background: transparent;
+  color: var(--text);
+  border: 1px solid var(--border);
+}
+
+.controls {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 2rem 0 1rem;
+  gap: 1rem;
+}
+
+#search {
+  width: min(550px, 100%);
+  border-radius: .7rem;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text);
+  padding: .75rem .9rem;
+}
+#stats { color: var(--muted); }
+
+.catalog { display: grid; gap: 1rem; margin-bottom: 2rem; }
+.section {
+  border: 1px solid var(--border);
+  border-radius: .9rem;
+  overflow: hidden;
+  background: linear-gradient(180deg, var(--surface), #101933);
+}
+.section-header {
+  padding: .8rem 1rem;
+  background: rgba(255,255,255,.03);
+  border-bottom: 1px solid var(--border);
+  font-weight: 600;
+}
+.file-list { list-style: none; margin: 0; padding: .4rem; }
+.file-item {
+  display: flex;
+  justify-content: space-between;
+  gap: .8rem;
+  align-items: center;
+  padding: .55rem .7rem;
+  border-radius: .5rem;
+}
+.file-item:hover { background: var(--surface-2); }
+.file-name { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+.file-links { display: flex; gap: .7rem; flex-shrink: 0; }
+.file-links a {
+  color: var(--accent);
+  text-decoration: none;
+  font-size: .92rem;
+}
+.footer {
+  border-top: 1px solid var(--border);
+  padding: 1.2rem 0 2rem;
+  color: var(--muted);
+}
+code { color: var(--accent-2); }
+
+@media (max-width: 720px) {
+  .file-item { flex-direction: column; align-items: flex-start; }
+}


### PR DESCRIPTION
### Motivation
- Publish the repository as a simple GitHub Pages site and provide a browsable, searchable catalog of the repo contents under a dedicated `/site` folder.
- Provide direct `GitHub` and `Raw` links for each file so materials (guides, scripts, wiki notes) are easily accessible from the site.

### Description
- Added a static site under `site/` with `index.html`, `styles.css` and client logic in `app.js` to render a catalog, enable search, and detect `owner/repo` from the Pages URL to build links.
- Generated `site/content-index.json` that catalogs repository files grouped by top-level directory (excluded `site/`).
- Added `site/README.md` with instructions to enable GitHub Pages to serve the `/site` folder from the `main` branch.
- UI is a responsive, dark-themed landing page that lists files by section and provides `GitHub` and `Raw` links for each entry.

### Testing
- Validated generated JSON with `python -m json.tool site/content-index.json` and the check succeeded.
- Served the `site/` folder locally via `python -m http.server 4173` and verified assets (`index.html`, `styles.css`, `app.js`, `content-index.json`) loaded successfully.
- Automated Playwright run loaded the page and produced a screenshot of the home page, confirming client-side rendering succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0055658f4833298b107bb50eb06a4)