### PR TITLE
Add linux-help folder with import instructions

### DIFF
--- a/linux-help/README.md
+++ b/linux-help/README.md
@@ -1,0 +1,14 @@
+# linux-help import
+
+Не удалось автоматически скопировать статьи из `https://github.com/soulpastwk/linux-help` в этой среде, потому что исходящие запросы к GitHub блокируются (`CONNECT tunnel failed, response 403`).
+
+Чтобы импортировать все статьи локально, выполните:
+
+```bash
+git clone https://github.com/soulpastwk/linux-help /tmp/linux-help-src
+mkdir -p linux-help
+cp -r /tmp/linux-help-src/* linux-help/
+cp -r /tmp/linux-help-src/.github linux-help/ 2>/dev/null || true
+```
+
+После этого можно закоммитить содержимое папки `linux-help`.


### PR DESCRIPTION
### Motivation
- Требуется скопировать статьи из `https://github.com/soulpastwk/linux-help` в корень проекта, но среда блокирует исходящие запросы к GitHub, поэтому добавляю заглушку с инструкциями для локального импорта.

### Description
- Создана папка `linux-help/` и файл `linux-help/README.md`, который объясняет ограничение доступа и содержит команды `git clone` + `cp` для локального копирования содержимого репозитория при наличии сетевого доступа.

### Testing
- Попытки `git clone --depth 1 https://github.com/soulpastwk/linux-help /tmp/linux-help-src` и `curl -I https://raw.githubusercontent.com/soulpastwk/linux-help/main/README.md` завершились с ошибкой сети (`CONNECT tunnel failed, response 403`), а локальные проверки `git status --short` и `nl -ba linux-help/README.md` подтвердили наличие и содержимое файла (успешно).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b14118cd68833294c12307b75bf04a)