### PR TITLE
Add Grafana/Prometheus install guide and automation scripts

### DIFF
--- a/files/install_grafana_prometheus.sh
+++ b/files/install_grafana_prometheus.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+set -e
+
+# Установка Prometheus + Grafana (без Node Exporter)
+apt update && apt upgrade -y
+apt install -y wget tar software-properties-common apt-transport-https gnupg
+
+# Prometheus
+useradd --no-create-home --shell /bin/false prometheus || true
+mkdir -p /etc/prometheus /var/lib/prometheus
+chown prometheus:prometheus /var/lib/prometheus
+
+VER=3.9.0
+cd /tmp
+wget https://github.com/prometheus/prometheus/releases/download/v${VER}/prometheus-${VER}.linux-amd64.tar.gz
+tar xvf prometheus-${VER}.linux-amd64.tar.gz
+cp prometheus-${VER}.linux-amd64/prometheus prometheus-${VER}.linux-amd64/promtool /usr/local/bin/
+chown prometheus:prometheus /usr/local/bin/prometheus /usr/local/bin/promtool
+
+cat > /etc/prometheus/prometheus.yml <<'PROMEOF'
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+  scrape_timeout: 10s
+
+rule_files: []
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: ['localhost:9090']
+        labels:
+          instance: Central-Prometheus
+          group: central
+PROMEOF
+
+chown -R prometheus:prometheus /etc/prometheus /var/lib/prometheus
+rm -rf prometheus-${VER}.linux-amd64*
+
+cat > /etc/systemd/system/prometheus.service <<'EOF2'
+[Unit]
+Description=Prometheus
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+User=prometheus
+Group=prometheus
+Type=simple
+ExecStart=/usr/local/bin/prometheus \
+  --config.file=/etc/prometheus/prometheus.yml \
+  --storage.tsdb.path=/var/lib/prometheus \
+  --storage.tsdb.retention.time=200h \
+  --web.enable-lifecycle \
+  --web.enable-admin-api
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+EOF2
+
+systemctl daemon-reload
+systemctl enable --now prometheus
+
+# Grafana
+install -d -m 0755 /etc/apt/keyrings
+wget -q -O - https://apt.grafana.com/gpg.key | gpg --dearmor -o /etc/apt/keyrings/grafana.gpg
+echo "deb [signed-by=/etc/apt/keyrings/grafana.gpg] https://apt.grafana.com stable main" > /etc/apt/sources.list.d/grafana.list
+apt update
+apt install -y grafana
+systemctl daemon-reload
+systemctl enable --now grafana-server
+
+echo ""
+echo "✅ Установка завершена"
+echo "Откройте Grafana: http://<SERVER_IP>:3000"
+echo "Логин/пароль по умолчанию: admin/admin"
+echo "Порты: 9090/tcp (Prometheus), 3000/tcp (Grafana), 9100/tcp (Node Exporter на агентах)"

--- a/files/install_node_exporter_agent.sh
+++ b/files/install_node_exporter_agent.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -e
+
+# Установка Node Exporter на ноду/агент для мониторинга
+apt update && apt upgrade -y
+apt install -y wget tar
+
+useradd --no-create-home --shell /bin/false node_exporter || true
+VER=1.9.1
+cd /tmp
+wget https://github.com/prometheus/node_exporter/releases/download/v${VER}/node_exporter-${VER}.linux-amd64.tar.gz
+tar xvf node_exporter-${VER}.linux-amd64.tar.gz
+cp node_exporter-${VER}.linux-amd64/node_exporter /usr/local/bin/
+chown node_exporter:node_exporter /usr/local/bin/node_exporter
+rm -rf node_exporter-${VER}.linux-amd64*
+
+cat > /etc/systemd/system/node_exporter.service <<'EOFSVC'
+[Unit]
+Description=Node Exporter
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+User=node_exporter
+Group=node_exporter
+Type=simple
+ExecStart=/usr/local/bin/node_exporter --collector.filesystem.ignored-mount-points=^/(sys|proc|dev|host|etc)(\\|$)
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+EOFSVC
+
+systemctl daemon-reload
+systemctl enable --now node_exporter
+
+echo "✅ Node Exporter запущен на порту 9100"

--- a/my-wiki/Grafana Prometheus Setup.md
+++ b/my-wiki/Grafana Prometheus Setup.md
@@ -1,0 +1,143 @@
+# 🚨 Дисклеймер
+
+> ⚠️ Установка Grafana/Prometheus в вашем сценарии возможна только:
+> - 🌍 на **заграничный сервер**, или
+> - 🇷🇺 на **российский сервер только под VPN/туннелем** (чтобы сервер имел стабильный доступ к внешним репозиториям и релизам).
+
+---
+
+# 📊 Установка Grafana + Prometheus (центральный сервер)
+
+Этот гайд ставит:
+- ✅ Prometheus (сбор метрик)
+- ✅ Grafana (дашборды)
+- ❗ Node Exporter вынесен в **отдельный скрипт** для нод/агентов, которые нужно мониторить.
+
+## 1) 🚀 Установка одной командой
+
+Выполните на центральном сервере:
+
+```bash
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/<YOUR_REPO>/<YOUR_BRANCH>/files/install_grafana_prometheus.sh)"
+```
+
+Или локально из репозитория:
+
+```bash
+sudo bash files/install_grafana_prometheus.sh
+```
+
+После установки:
+- Grafana: `http://SERVER_IP:3000`
+- Логин/пароль по умолчанию: `admin/admin`
+- Prometheus: `http://SERVER_IP:9090`
+
+---
+
+## 2) 🔌 Подключение нод (агентов) для мониторинга
+
+На **каждой удалённой ноде**, которую нужно мониторить, запустите:
+
+```bash
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/<YOUR_REPO>/<YOUR_BRANCH>/files/install_node_exporter_agent.sh)"
+```
+
+Или локально из репозитория:
+
+```bash
+sudo bash files/install_node_exporter_agent.sh
+```
+
+Node Exporter будет слушать `9100/tcp`.
+
+---
+
+## 3) 🧩 Добавьте ноды в конфиг Prometheus (на центральном сервере)
+
+Отредактируйте `/etc/prometheus/prometheus.yml`:
+
+```yml
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+  scrape_timeout: 10s
+
+rule_files: []
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: ['localhost:9090']
+        labels:
+          instance: Central-Prometheus
+          group: central
+
+  - job_name: nodes
+    static_configs:
+      - targets: ['localhost:9100']
+        labels:
+          instance: Grafana
+          group: central
+      - targets: ['11.111.111.111:9100']
+        labels:
+          instance: 🇷🇺 Москва Remnawave
+          group: moscow
+      - targets: ['22.222.222.222:9100']
+        labels:
+          instance: 🇱🇻 Латвия YT no-ads 📺
+          group: latvia
+      - targets: ['33.33.33.33:9100']
+        labels:
+          instance: 🇩🇪 Германия - 3 YT no-ads 📺
+          group: germany
+      - targets: ['44.44.44.44:9100']
+        labels:
+          instance: 🇩🇪 Германия - Plus
+          group: germany
+```
+
+Примените изменения:
+
+```bash
+sudo systemctl restart prometheus
+```
+
+Проверка:
+
+```bash
+sudo systemctl status prometheus --no-pager
+curl -s http://localhost:9090/-/ready
+```
+
+---
+
+## 4) 🎛️ Настройка Grafana datasource
+
+1. Откройте `http://SERVER_IP:3000`
+2. Войдите `admin/admin`
+3. `Connections` → `Data sources` → `Add data source`
+4. Выберите **Prometheus**
+5. URL: `http://localhost:9090`
+6. Нажмите `Save & test` ✅
+
+---
+
+## 5) 🔥 Порты firewall
+
+Откройте необходимые порты:
+- `3000/tcp` — Grafana
+- `9090/tcp` — Prometheus
+- `9100/tcp` — Node Exporter (на агентах)
+
+---
+
+## 6) 🛠️ Полезные команды
+
+```bash
+sudo systemctl status grafana-server --no-pager
+sudo systemctl status prometheus --no-pager
+sudo journalctl -u grafana-server -n 100 --no-pager
+sudo journalctl -u prometheus -n 100 --no-pager
+```
+
+Удачной установки! 🚀📈


### PR DESCRIPTION
### Мотивация

* Обеспечить воспроизводимый процесс установки для центрального сервера Grafana + Prometheus в одну команду с четкими инструкциями по эксплуатации.
* Разделить установку Node Exporter на отдельный скрипт агента, чтобы на мониторируемых узлах запускался только агент.
* Включить дисклеймер о подключении (для иностранных серверов или российских серверов под VPN), настройке брандмауэра и источников данных, чтобы избежать распространенных проблем.

### Описание

* Добавлен файл `my-wiki/Grafana Prometheus Setup.md`, который содержит дисклеймер, команды для установки в одну строку, пример `prometheus.yml`, шаги для настройки источников данных в Grafana, список портов брандмауэра и полезные команды.
* Добавлен исполнимый файл `files/install_grafana_prometheus.sh`, который автоматизирует установку и настройку systemd для Prometheus и Grafana на центральном сервере.
* Добавлен исполнимый файл `files/install_node_exporter_agent.sh`, который устанавливает и включает Node Exporter как сервис systemd на удаленных/агентных узлах.

### Тестирование

* Запущена команда `bash -n files/install_grafana_prometheus.sh`, синтаксических ошибок не найдено.
* Запущена команда `bash -n files/install_node_exporter_agent.sh`, синтаксических ошибок не найдено.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7c2620cc0833286e6c0e0700d563d)