### PR TITLE
Docs: run control-docker as Docker CLI plugin (`docker control`)

### DIFF
--- a/my-wiki/Docker control.md
+++ b/my-wiki/Docker control.md
@@ -1,6 +1,6 @@
 # 🐳 Control Docker CLI v5.2 
 
-Интерактивный CLI-инструмент для удобного управления Docker прямо из терминала.
+Интерактивный CLI-инструмент для удобного управления Docker прямо из терминала через команду `docker control`.
 
 Скрипт позволяет управлять контейнерами, логами, compose-проектами, volumes, networks и Docker-ресурсами через простое текстовое меню.
 
@@ -20,7 +20,8 @@ sudo mkdir -p /opt/control-docker/log
 cd /opt/control-docker
 sudo wget -O /opt/control-docker/control-docker-v5.2-cli.sh https://raw.githubusercontent.com/r00t-man/MZT/3ab93f22126c46616201e07f37572848f9848f02/files/control-docker-v5.2-cli.sh
 sudo chmod +x /opt/control-docker/control-docker-v5.2-cli.sh
-sudo ln -sf /opt/control-docker/control-docker-v5.2-cli.sh /usr/local/bin/control-docker
+sudo mkdir -p /usr/local/lib/docker/cli-plugins
+sudo ln -sf /opt/control-docker/control-docker-v5.2-cli.sh /usr/local/lib/docker/cli-plugins/docker-control
 hash -r
 ```
 
@@ -183,12 +184,13 @@ sudo chmod +x /opt/control-docker/control-docker-v5.2-cli.sh
 
 ---
 
-## 5️⃣ Создать глобальную команду
+## 5️⃣ Подключить команду `docker control`
 
-Чтобы запускать скрипт одной командой:
+Чтобы запускать скрипт как подкоманду Docker:
 
 ```bash
-sudo ln -sf /opt/control-docker/control-docker-v5.2-cli.sh /usr/local/bin/control-docker
+sudo mkdir -p /usr/local/lib/docker/cli-plugins
+sudo ln -sf /opt/control-docker/control-docker-v5.2-cli.sh /usr/local/lib/docker/cli-plugins/docker-control
 ```
 
 ---
@@ -202,7 +204,7 @@ hash -r
 ### Зачем нужен `hash -r`
 
 Bash кэширует пути к командам.
-После создания новой команды (`control-docker`) нужно очистить этот кеш, чтобы оболочка увидела новую команду.
+После подключения новой подкоманды (`docker control`) полезно очистить этот кеш, чтобы оболочка увидела изменения сразу.
 
 ---
 
@@ -211,7 +213,7 @@ Bash кэширует пути к командам.
 После установки скрипт можно запускать так:
 
 ```bash
-control-docker
+docker control
 ```
 
 Откроется интерактивное CLI-меню.
@@ -284,6 +286,12 @@ Ctrl+C
  └─ log/
       container-name/
            log-files
+```
+
+CLI plugin Docker будет подключён через путь:
+
+```
+/usr/local/lib/docker/cli-plugins/docker-control
 ```
 
 ---


### PR DESCRIPTION
### Motivation
- Make the tool available as a Docker CLI subcommand so users run it with `docker control` instead of a separate `control-docker` command.
- Update installation instructions and examples to follow the Docker CLI plugin layout so the invocation and paths are consistent.

### Description
- Updated `my-wiki/Docker control.md` to mention `docker control` in the header and usage examples and to replace the previous `/usr/local/bin/control-docker` approach with Docker CLI plugin install steps into `/usr/local/lib/docker/cli-plugins/docker-control`.
- Replaced install and launch examples to create the `cli-plugins` directory and symlink the script as `/usr/local/lib/docker/cli-plugins/docker-control` and adjusted the `hash -r` guidance accordingly.
- Added an explicit note showing the plugin path `/usr/local/lib/docker/cli-plugins/docker-control` in the documentation.
- Did not modify the script logic in `files/control-docker-v5.2-cli.sh` since the script itself does not contain a separate `control-docker` launcher invocation.

### Testing
- Ran a shell syntax check with `bash -n files/control-docker-v5.2-cli.sh` which completed without errors.
- Used `rg -n` searches to verify the documentation now references `docker control` and the plugin path ` /usr/local/lib/docker/cli-plugins/docker-control` and that no standalone launcher invocation remained in the targeted files.
- Verified the updated documentation renders the new install and run commands as expected in the edited file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd456677ac8332b22aa009a7c48125)