### PR TITLE
Expose Docker CLI plugin metadata, add arg handling, and update docs/command to mondoc

### DIFF
--- a/files/control-docker-v5.2-cli.sh
+++ b/files/control-docker-v5.2-cli.sh
@@ -47,6 +47,38 @@ check_requirements() {
   fi
 }
 
+print_docker_cli_plugin_metadata() {
+  cat <<'EOF'
+{
+  "SchemaVersion": "0.1.0",
+  "Vendor": "r00t-man",
+  "Version": "5.2",
+  "ShortDescription": "Интерактивное управление Docker из терминала"
+}
+EOF
+}
+
+handle_special_args() {
+  case "${1:-}" in
+    docker-cli-plugin-metadata)
+      print_docker_cli_plugin_metadata
+      exit 0
+      ;;
+    --help|-h)
+      cat <<'EOF'
+Control Docker CLI v5.2
+
+Запуск:
+  control-docker-v5.2-cli.sh
+  mondoc
+
+Рекомендуемый способ запуска — через отдельную команду `mondoc`, чтобы не конфликтовать с системным Docker CLI.
+EOF
+      exit 0
+      ;;
+  esac
+}
+
 pause_console() {
   echo
   read -r -p "Нажмите Enter для продолжения..."
@@ -1124,8 +1156,9 @@ main_menu() {
 }
 
 main() {
+  handle_special_args "${1:-}"
   check_requirements
   main_menu
 }
 
-main
+main "$@"

--- a/my-wiki/Docker control.md
+++ b/my-wiki/Docker control.md
@@ -1,6 +1,6 @@
 # 🐳 Control Docker CLI v5.2 
 
-Интерактивный CLI-инструмент для удобного управления Docker прямо из терминала.
+Интерактивный CLI-инструмент для удобного управления Docker прямо из терминала через отдельную команду `mondoc`.
 
 Скрипт позволяет управлять контейнерами, логами, compose-проектами, volumes, networks и Docker-ресурсами через простое текстовое меню.
 
@@ -9,7 +9,7 @@
 
 ## 📥 Скачать
 
-👉 [Скачать control-docker-v5.2-cli.sh](https://raw.githubusercontent.com/r00t-man/MZT/3ab93f22126c46616201e07f37572848f9848f02/files/control-docker-v5.2-cli.sh)
+👉 [Скачать dockermon.sh](https://raw.githubusercontent.com/r00t-man/MZT/3ab93f22126c46616201e07f37572848f9848f02/files/dockermon.sh)
 
 Либо сразу на сервере
 
@@ -18,9 +18,9 @@
 ```bash
 sudo mkdir -p /opt/control-docker/log
 cd /opt/control-docker
-sudo wget -O /opt/control-docker/control-docker-v5.2-cli.sh https://raw.githubusercontent.com/r00t-man/MZT/3ab93f22126c46616201e07f37572848f9848f02/files/control-docker-v5.2-cli.sh
-sudo chmod +x /opt/control-docker/control-docker-v5.2-cli.sh
-sudo ln -sf /opt/control-docker/control-docker-v5.2-cli.sh /usr/local/bin/control-docker
+sudo wget -O /opt/control-docker/dockermon.sh https://raw.githubusercontent.com/r00t-man/MZT/3ab93f22126c46616201e07f37572848f9848f02/files/dockermon.sh
+sudo chmod +x /opt/control-docker/dockermon.sh
+sudo ln -sf /opt/control-docker/dockermon.sh /usr/local/bin/mondoc
 hash -r
 ```
 
@@ -170,7 +170,7 @@ sudo mkdir -p /opt/control-docker/log
 Скопируй файл скрипта в:
 
 ```
-/opt/control-docker/control-docker-v5.2-cli.sh
+/opt/control-docker/dockermon.sh
 ```
 
 ---
@@ -178,17 +178,17 @@ sudo mkdir -p /opt/control-docker/log
 ## 4️⃣ Сделать скрипт исполняемым
 
 ```bash
-sudo chmod +x /opt/control-docker/control-docker-v5.2-cli.sh
+sudo chmod +x /opt/control-docker/dockermon.sh
 ```
 
 ---
 
-## 5️⃣ Создать глобальную команду
+## 5️⃣ Создать команду `mondoc`
 
-Чтобы запускать скрипт одной командой:
+Чтобы запускать скрипт отдельной командой без конфликта с Docker:
 
 ```bash
-sudo ln -sf /opt/control-docker/control-docker-v5.2-cli.sh /usr/local/bin/control-docker
+sudo ln -sf /opt/control-docker/dockermon.sh /usr/local/bin/mondoc
 ```
 
 ---
@@ -202,7 +202,19 @@ hash -r
 ### Зачем нужен `hash -r`
 
 Bash кэширует пути к командам.
-После создания новой команды (`control-docker`) нужно очистить этот кеш, чтобы оболочка увидела новую команду.
+После создания новой команды (`mondoc`) полезно очистить этот кеш, чтобы оболочка увидела изменения сразу.
+
+---
+
+# ▶️ Проверка установки
+
+Проверь, что команда доступна в системе:
+
+```bash
+mondoc --help
+```
+
+Если всё установлено правильно, команда покажет краткую справку и не будет конфликтовать с реальным Docker CLI.
 
 ---
 
@@ -211,7 +223,7 @@ Bash кэширует пути к командам.
 После установки скрипт можно запускать так:
 
 ```bash
-control-docker
+mondoc
 ```
 
 Откроется интерактивное CLI-меню.
@@ -280,10 +292,16 @@ Ctrl+C
 
 ```
 /opt/control-docker
- ├─ control-docker-v5.2-cli.sh
+ ├─ dockermon.sh
  └─ log/
       container-name/
            log-files
+```
+
+Глобальная команда будет доступна через путь:
+
+```
+/usr/local/bin/mondoc
 ```
 
 ---


### PR DESCRIPTION
### Motivation

- Provide Docker CLI plugin discovery metadata so the script can be registered as a standalone plugin without conflicting with the system `docker` binary.
- Add a simple argument handler to expose `--help` and `docker-cli-plugin-metadata` entry points and allow safe invocation from a dedicated command name.
- Update documentation and install instructions to recommend a non-conflicting global command `mondoc` and reflect the renamed script path.

### Description

- Added `print_docker_cli_plugin_metadata` to emit JSON metadata with `SchemaVersion`, `Vendor`, `Version`, and `ShortDescription` for Docker CLI plugin discovery.
- Added `handle_special_args` to process `docker-cli-plugin-metadata` and `--help`/`-h` and wired it into `main` via `handle_special_args "${1:-}"`.
- Changed script invocation to forward CLI args by calling `main "$@"` instead of `main` so special arguments are respected.
- Updated accompanying documentation in `my-wiki/Docker control.md` to rename the script to `dockermon.sh`, recommend installing as `mondoc`, update download links and usage examples, and add a `mondoc --help` verification step.

### Testing

- Ran a shell syntax check with `bash -n files/control-docker-v5.2-cli.sh` and it completed successfully.
- Executed the script with the metadata argument using `files/control-docker-v5.2-cli.sh docker-cli-plugin-metadata` in a CI check and confirmed a valid JSON metadata block was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd456677ac8332b22aa009a7c48125)