### PR TITLE
docs: add screen guide link and scrmenu quick-install across READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,14 @@ bash <(curl -Ls https://raw.githubusercontent.com/r00t-man/MZT/main/files/server
 - 🐳 Dockermon — интерактивное управление Docker из терминала
 - 🖥️ Работа со `screen` — мультиплексор терминала
 
+📘 Прямой файл: [MZT/info/Работа со `screen` — мультиплексор терминала.md](./info/Работа%20со%20screen%20—%20мультиплексор%20терминала.md)
+
+🚀 Быстрая установка `scrmenu` (CLI-меню для `screen`):
+
+```bash
+sudo bash -c 'curl -fsSL https://raw.githubusercontent.com/r00t-man/MZT/refs/heads/main/files/scrmenu.sh -o /usr/local/bin/scrmenu && chmod +x /usr/local/bin/scrmenu'
+```
+
 👉 https://github.com/r00t-man/MZT/tree/main/info
 
 ---

--- a/Server_Security/README.md
+++ b/Server_Security/README.md
@@ -74,3 +74,9 @@ bash <(curl -Ls https://raw.githubusercontent.com/r00t-man/MZT/main/files/server
 Для обновлений, миграций и запуска процессов без риска обрыва при отключении SSH можно использовать `screen`:
 
 - 📘 [Работа со `screen` — мультиплексор терминала](../info/Работа%20со%20screen%20—%20мультиплексор%20терминала.md)
+
+**Быстрая установка `scrmenu` (CLI-меню для `screen`):**
+
+```bash
+sudo bash -c 'curl -fsSL https://raw.githubusercontent.com/r00t-man/MZT/refs/heads/main/files/scrmenu.sh -o /usr/local/bin/scrmenu && chmod +x /usr/local/bin/scrmenu'
+```

--- a/info/README.md
+++ b/info/README.md
@@ -15,6 +15,12 @@
 - 🐳 [Dockermon — интерактивное управление Docker из терминала](./Dockermon%20—%20интерактивное%20управление%20Docker%20из%20терминала.md)
 - 🖥️ [Работа со `screen` — мультиплексор терминала](./Работа%20со%20screen%20—%20мультиплексор%20терминала.md)
 
+**Быстрая установка `scrmenu` (CLI-меню для `screen`):**
+
+```bash
+sudo bash -c 'curl -fsSL https://raw.githubusercontent.com/r00t-man/MZT/refs/heads/main/files/scrmenu.sh -o /usr/local/bin/scrmenu && chmod +x /usr/local/bin/scrmenu'
+```
+
 
 ## 🔐 Новая статья в Server Security
 

--- a/my-wiki/readme.md
+++ b/my-wiki/readme.md
@@ -218,6 +218,12 @@ bash <(curl -Ls https://raw.githubusercontent.com/r00t-man/MZT/main/files/server
 
 [https://github.com/r00t-man/MZT/blob/main/info/%D0%A0%D0%B0%D0%B1%D0%BE%D1%82%D0%B0%20%D1%81%D0%BE%20screen%20%E2%80%94%20%D0%BC%D1%83%D0%BB%D1%8C%D1%82%D0%B8%D0%BF%D0%BB%D0%B5%D0%BA%D1%81%D0%BE%D1%80%20%D1%82%D0%B5%D1%80%D0%BC%D0%B8%D0%BD%D0%B0%D0%BB%D0%B0.md](https://github.com/r00t-man/MZT/blob/main/info/%D0%A0%D0%B0%D0%B1%D0%BE%D1%82%D0%B0%20%D1%81%D0%BE%20screen%20%E2%80%94%20%D0%BC%D1%83%D0%BB%D1%8C%D1%82%D0%B8%D0%BF%D0%BB%D0%B5%D0%BA%D1%81%D0%BE%D1%80%20%D1%82%D0%B5%D1%80%D0%BC%D0%B8%D0%BD%D0%B0%D0%BB%D0%B0.md)
 
+🚀 **Быстрая установка `scrmenu` (CLI-меню для `screen`):**
+
+```bash
+sudo bash -c 'curl -fsSL https://raw.githubusercontent.com/r00t-man/MZT/refs/heads/main/files/scrmenu.sh -o /usr/local/bin/scrmenu && chmod +x /usr/local/bin/scrmenu'
+```
+
 ---
 
 # ⚠️ Дисклеймер


### PR DESCRIPTION
### Motivation
- Make the `screen` guide and a one-line installer for the `scrmenu` helper easily discoverable and consistent across repository documentation.

### Description
- Added a direct link to `info/Работа со screen — мультиплексор терминала.md` in the main `README.md`.
- Inserted a one-line quick-install snippet for `scrmenu` in `README.md`, `info/README.md`, `my-wiki/readme.md`, and `Server_Security/README.md`.
- These are documentation-only edits and do not modify any scripts or code.

### Testing
- Searched files with `rg` to confirm `screen` and `scrmenu` entries are present in the four updated files and the searches returned the expected matches.
- Inspected diffs for `README.md`, `info/README.md`, `my-wiki/readme.md`, and `Server_Security/README.md` to verify only documentation was changed.
- Performed `git status` and committed the updated files successfully; all automated checks executed in the rollout completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4c1140f78832289c3d32c3ec83acc)